### PR TITLE
fix filename bug

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -43,7 +43,7 @@ func (c *Canvas) SetQuality(quality int) {
 
 // save canvas into a file
 func (c *Canvas) Save(filename string, filetype string) error {
-	f, err := os.Create("filename")
+	f, err := os.Create(filename)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Hello :hand:
I found a bug in the `Save` method and i fixed this bug :v:
The problem was that it didn't save the file name correctly for example `test` and only saved as `filename` file

I find another little bugs in this project :wink: